### PR TITLE
chore: upgrade Go to 1.25.8 to fix CVE-2026-25679

### DIFF
--- a/go-src/go.mod
+++ b/go-src/go.mod
@@ -1,6 +1,6 @@
 module github.com/api7/lua-resty-aws-s3
 
-go 1.23.8
+go 1.25.8
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.5


### PR DESCRIPTION
## Summary
Upgrade Go version from 1.23.8 to 1.25.8 to address CVE-2026-25679 (HIGH severity).

## Changes
- `go-src/go.mod`: Updated `go` directive from 1.23.8 to 1.25.8

## Context
Ref: https://github.com/api7/api7-ee-3-gateway/issues/1302

The gateway image vulnerability scan flagged `s3.so` as containing a HIGH CVE. Upgrading the Go toolchain version resolves this.

## Test
No new test cases needed — this is a Go toolchain version bump with no logic changes. Build verified locally (`s3.so` compiles successfully with Go 1.25.8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version requirement to 1.25.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->