### PR TITLE
fix: support S3 path-style fallback endpoint

### DIFF
--- a/go-src/main.go
+++ b/go-src/main.go
@@ -1,18 +1,20 @@
 package main
 
-import (
-	"C"
+/*
+#include <stdlib.h>
+*/
+import "C"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-)
 import (
 	"bytes"
 	"context"
 	"io"
 	"unsafe"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 //export getObject
@@ -60,7 +62,7 @@ func putObject(cBucket *C.char, cKey *C.char, cContent *C.char, cRegion *C.char,
 	usePathStyle := cUsePathStyle != 0
 
 	cfg, err := getConfiguration(region, accessKey, secretKey, customEndpoint)
-	if cfg == nil {
+	if err != nil {
 		return unsafe.Pointer(C.CString(err.Error()))
 	}
 	cli := newS3Client(*cfg, usePathStyle)
@@ -104,6 +106,11 @@ func newS3Client(cfg aws.Config, usePathStyle bool) *s3.Client {
 	return s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.UsePathStyle = usePathStyle
 	})
+}
+
+//export freeCString
+func freeCString(ptr unsafe.Pointer) {
+	C.free(ptr)
 }
 
 func main() {

--- a/go-src/main.go
+++ b/go-src/main.go
@@ -16,19 +16,20 @@ import (
 )
 
 //export getObject
-func getObject(cBucket *C.char, cKey *C.char, cRegion *C.char, cAccessKey *C.char, cSecretKey *C.char, cCustomEndpoint *C.char) (unsafe.Pointer, unsafe.Pointer) {
+func getObject(cBucket *C.char, cKey *C.char, cRegion *C.char, cAccessKey *C.char, cSecretKey *C.char, cCustomEndpoint *C.char, cUsePathStyle C.int) (unsafe.Pointer, unsafe.Pointer) {
 	region := C.GoString(cRegion)
 	accessKey := C.GoString(cAccessKey)
 	secretKey := C.GoString(cSecretKey)
 	customEndpoint := C.GoString(cCustomEndpoint)
 	bucket := C.GoString(cBucket)
 	key := C.GoString(cKey)
+	usePathStyle := cUsePathStyle != 0
 
 	cfg, err := getConfiguration(region, accessKey, secretKey, customEndpoint)
 	if err != nil {
 		return nil, unsafe.Pointer(C.CString(err.Error()))
 	}
-	cli := s3.NewFromConfig(*cfg)
+	cli := newS3Client(*cfg, usePathStyle)
 
 	out, err := cli.GetObject(context.TODO(), &s3.GetObjectInput{
 		Bucket: aws.String(bucket),
@@ -48,7 +49,7 @@ func getObject(cBucket *C.char, cKey *C.char, cRegion *C.char, cAccessKey *C.cha
 }
 
 //export putObject
-func putObject(cBucket *C.char, cKey *C.char, cContent *C.char, cRegion *C.char, cAccessKey *C.char, cSecretKey *C.char, cCustomEndpoint *C.char) unsafe.Pointer {
+func putObject(cBucket *C.char, cKey *C.char, cContent *C.char, cRegion *C.char, cAccessKey *C.char, cSecretKey *C.char, cCustomEndpoint *C.char, cUsePathStyle C.int) unsafe.Pointer {
 	region := C.GoString(cRegion)
 	accessKey := C.GoString(cAccessKey)
 	secretKey := C.GoString(cSecretKey)
@@ -56,12 +57,13 @@ func putObject(cBucket *C.char, cKey *C.char, cContent *C.char, cRegion *C.char,
 	bucket := C.GoString(cBucket)
 	key := C.GoString(cKey)
 	content := C.GoString(cContent)
+	usePathStyle := cUsePathStyle != 0
 
 	cfg, err := getConfiguration(region, accessKey, secretKey, customEndpoint)
 	if cfg == nil {
 		return unsafe.Pointer(C.CString(err.Error()))
 	}
-	cli := s3.NewFromConfig(*cfg)
+	cli := newS3Client(*cfg, usePathStyle)
 
 	_, err = cli.PutObject(context.TODO(), &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
@@ -96,6 +98,12 @@ func getConfiguration(region, accessKey, secretKey, customEndpoint string) (*aws
 		cfg.BaseEndpoint = &customEndpoint
 	}
 	return &cfg, nil
+}
+
+func newS3Client(cfg aws.Config, usePathStyle bool) *s3.Client {
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.UsePathStyle = usePathStyle
+	})
 }
 
 func main() {

--- a/go-src/main_test.go
+++ b/go-src/main_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestUsePathStyleWithEndpointPrefix(t *testing.T) {
+	const (
+		prefix = "/fallback-cp-config"
+		bucket = "resource-bucket"
+		key    = "gwid"
+		body   = "payload"
+	)
+
+	for _, usePathStyle := range []bool{false, true} {
+		t.Run("use_path_style_"+map[bool]string{false: "false", true: "true"}[usePathStyle], func(t *testing.T) {
+			var requests []string
+			var stored string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests = append(requests, r.Method+" "+r.Host+r.URL.RequestURI())
+				if r.URL.Path != prefix+"/"+bucket+"/"+key {
+					http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+					return
+				}
+
+				switch r.Method {
+				case http.MethodPut:
+					data, err := io.ReadAll(r.Body)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+					stored = string(data)
+					w.WriteHeader(http.StatusOK)
+				case http.MethodGet:
+					_, _ = w.Write([]byte(stored))
+				default:
+					http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+				}
+			}))
+			defer server.Close()
+
+			serverAddr := strings.TrimPrefix(server.URL, "http://")
+			_, port, err := net.SplitHostPort(serverAddr)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			endpoint := "http://minio.test:" + port + prefix
+			cli := newS3Client(aws.Config{
+				Region:       "us-east-1",
+				Credentials:  credentials.NewStaticCredentialsProvider("access", "secret", ""),
+				BaseEndpoint: &endpoint,
+				HTTPClient: &http.Client{
+					Transport: &http.Transport{
+						DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+							var d net.Dialer
+							return d.DialContext(ctx, network, serverAddr)
+						},
+					},
+					Timeout: 5 * time.Second,
+				},
+				Retryer: func() aws.Retryer {
+					return retry.NewStandard(func(o *retry.StandardOptions) {
+						o.MaxAttempts = 1
+					})
+				},
+			}, usePathStyle)
+
+			_, err = cli.PutObject(context.Background(), &s3.PutObjectInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+				Body:   strings.NewReader(body),
+			})
+			if usePathStyle {
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				out, err := cli.GetObject(context.Background(), &s3.GetObjectInput{
+					Bucket: aws.String(bucket),
+					Key:    aws.String(key),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err := io.ReadAll(out.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(got) != body {
+					t.Fatalf("expected body %q, got %q", body, string(got))
+				}
+				want := []string{
+					"PUT minio.test:" + port + "/fallback-cp-config/resource-bucket/gwid?x-id=PutObject",
+					"GET minio.test:" + port + "/fallback-cp-config/resource-bucket/gwid?x-id=GetObject",
+				}
+				if strings.Join(requests, "\n") != strings.Join(want, "\n") {
+					t.Fatalf("expected requests %v, got %v", want, requests)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected PutObject to fail without path-style")
+			}
+			want := []string{
+				"PUT resource-bucket.minio.test:" + port + "/fallback-cp-config/gwid?x-id=PutObject",
+			}
+			if strings.Join(requests, "\n") != strings.Join(want, "\n") {
+				t.Fatalf("expected requests %v, got %v", want, requests)
+			}
+		})
+	}
+}

--- a/go-src/main_test.go
+++ b/go-src/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,10 +27,13 @@ func TestUsePathStyleWithEndpointPrefix(t *testing.T) {
 
 	for _, usePathStyle := range []bool{false, true} {
 		t.Run("use_path_style_"+map[bool]string{false: "false", true: "true"}[usePathStyle], func(t *testing.T) {
-			var requests []string
+			var mu sync.Mutex
+			var requests []recordedRequest
 			var stored string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				requests = append(requests, r.Method+" "+r.Host+r.URL.RequestURI())
+				mu.Lock()
+				requests = append(requests, recordedRequest{method: r.Method, host: r.Host, path: r.URL.Path})
+				mu.Unlock()
 				if r.URL.Path != prefix+"/"+bucket+"/"+key {
 					http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
 					return
@@ -42,10 +46,15 @@ func TestUsePathStyleWithEndpointPrefix(t *testing.T) {
 						http.Error(w, err.Error(), http.StatusInternalServerError)
 						return
 					}
+					mu.Lock()
 					stored = string(data)
+					mu.Unlock()
 					w.WriteHeader(http.StatusOK)
 				case http.MethodGet:
-					_, _ = w.Write([]byte(stored))
+					mu.Lock()
+					body := stored
+					mu.Unlock()
+					_, _ = w.Write([]byte(body))
 				default:
 					http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
 				}
@@ -96,6 +105,7 @@ func TestUsePathStyleWithEndpointPrefix(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				defer out.Body.Close()
 				got, err := io.ReadAll(out.Body)
 				if err != nil {
 					t.Fatal(err)
@@ -103,11 +113,14 @@ func TestUsePathStyleWithEndpointPrefix(t *testing.T) {
 				if string(got) != body {
 					t.Fatalf("expected body %q, got %q", body, string(got))
 				}
-				want := []string{
-					"PUT minio.test:" + port + "/fallback-cp-config/resource-bucket/gwid?x-id=PutObject",
-					"GET minio.test:" + port + "/fallback-cp-config/resource-bucket/gwid?x-id=GetObject",
+				want := []recordedRequest{
+					{method: "PUT", host: "minio.test:" + port, path: "/fallback-cp-config/resource-bucket/gwid"},
+					{method: "GET", host: "minio.test:" + port, path: "/fallback-cp-config/resource-bucket/gwid"},
 				}
-				if strings.Join(requests, "\n") != strings.Join(want, "\n") {
+				mu.Lock()
+				gotRequests := append([]recordedRequest(nil), requests...)
+				mu.Unlock()
+				if strings.Join(formatRequests(gotRequests), "\n") != strings.Join(formatRequests(want), "\n") {
 					t.Fatalf("expected requests %v, got %v", want, requests)
 				}
 				return
@@ -116,12 +129,29 @@ func TestUsePathStyleWithEndpointPrefix(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected PutObject to fail without path-style")
 			}
-			want := []string{
-				"PUT resource-bucket.minio.test:" + port + "/fallback-cp-config/gwid?x-id=PutObject",
+			want := []recordedRequest{
+				{method: "PUT", host: "resource-bucket.minio.test:" + port, path: "/fallback-cp-config/gwid"},
 			}
-			if strings.Join(requests, "\n") != strings.Join(want, "\n") {
+			mu.Lock()
+			gotRequests := append([]recordedRequest(nil), requests...)
+			mu.Unlock()
+			if strings.Join(formatRequests(gotRequests), "\n") != strings.Join(formatRequests(want), "\n") {
 				t.Fatalf("expected requests %v, got %v", want, requests)
 			}
 		})
 	}
+}
+
+type recordedRequest struct {
+	method string
+	host   string
+	path   string
+}
+
+func formatRequests(requests []recordedRequest) []string {
+	out := make([]string, 0, len(requests))
+	for _, req := range requests {
+		out = append(out, req.method+" "+req.host+req.path)
+	}
+	return out
 }

--- a/s3.lua
+++ b/s3.lua
@@ -32,7 +32,15 @@ ffi.cdef [[
   ReturnType getObject(const char *cBucket, const char *cKey, const char *cRegion, const char *cAccessKey, const char *cSecretKey, const char *cCustomEndpoint, int cUsePathStyle);
 
   void* putObject(const char *cBucket, const char *cKey, const char *cContent, const char *cRegion, const char *cAccessKey, const char *cSecretKey, const char *cCustomEndpoint, int cUsePathStyle);
+
+  void freeCString(void *ptr);
 ]]
+
+local function string_and_free(ptr)
+  local str = ffi.string(ptr)
+  go_s3.freeCString(ptr)
+  return str
+end
 
 function _M.get_object(bucket, key, region, access_key, secret_key, custom_endpoint, use_path_style)
   local return_type = go_s3.getObject(bucket, key, region, access_key, secret_key, custom_endpoint, use_path_style and 1 or 0)
@@ -40,16 +48,16 @@ function _M.get_object(bucket, key, region, access_key, secret_key, custom_endpo
   local err = return_type.r1
 
   if res == nil then
-    return nil, ffi.string(err)
+    return nil, string_and_free(err)
   end
-  return ffi.string(res), nil
+  return string_and_free(res), nil
 end
 
 function _M.put_object(bucket, key, content, region, access_key, secret_key, custom_endpoint, use_path_style)
   local err = go_s3.putObject(bucket, key, content, region, access_key, secret_key, custom_endpoint, use_path_style and 1 or 0)
 
   if err ~= nil then
-    return nil, ffi.string(err)
+    return nil, string_and_free(err)
   end
 
   return true

--- a/s3.lua
+++ b/s3.lua
@@ -29,13 +29,13 @@ ffi.cdef [[
     void* r1;
   } ReturnType;
 
-  ReturnType getObject(const char *cBucket, const char *cKey, const char *cRegion, const char *cAccessKey, const char *cSecretKey, const char *cCustomEndpoint);
+  ReturnType getObject(const char *cBucket, const char *cKey, const char *cRegion, const char *cAccessKey, const char *cSecretKey, const char *cCustomEndpoint, int cUsePathStyle);
 
-  void* putObject(const char *cBucket, const char *cKey, const char *cContent, const char *cRegion, const char *cAccessKey, const char *cSecretKey, const char *cCustomEndpoint);
+  void* putObject(const char *cBucket, const char *cKey, const char *cContent, const char *cRegion, const char *cAccessKey, const char *cSecretKey, const char *cCustomEndpoint, int cUsePathStyle);
 ]]
 
-function _M.get_object(bucket, key, region, access_key, secret_key, custom_endpoint)
-  local return_type = go_s3.getObject(bucket, key, region, access_key, secret_key, custom_endpoint)
+function _M.get_object(bucket, key, region, access_key, secret_key, custom_endpoint, use_path_style)
+  local return_type = go_s3.getObject(bucket, key, region, access_key, secret_key, custom_endpoint, use_path_style and 1 or 0)
   local res = return_type.r0
   local err = return_type.r1
 
@@ -45,8 +45,8 @@ function _M.get_object(bucket, key, region, access_key, secret_key, custom_endpo
   return ffi.string(res), nil
 end
 
-function _M.put_object(bucket, key, content, region, access_key, secret_key, custom_endpoint)
-  local err = go_s3.putObject(bucket, key, content, region, access_key, secret_key, custom_endpoint)
+function _M.put_object(bucket, key, content, region, access_key, secret_key, custom_endpoint, use_path_style)
+  local err = go_s3.putObject(bucket, key, content, region, access_key, secret_key, custom_endpoint, use_path_style and 1 or 0)
 
   if err ~= nil then
     return nil, ffi.string(err)


### PR DESCRIPTION
Add an explicit path-style option to the S3 FFI client so callers can keep the bucket name in the request path when using custom endpoints with a path prefix, such as MinIO behind /fallback-cp-config.

Tested with:
- go test ./...

This is needed by the gateway fallback_cp change that passes use_path_style from config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 object operations now support configurable path-style addressing for better compatibility with S3-compatible services and custom endpoints.
  * A new parameter enables toggling path-style behavior on both get and put operations.

* **Tests**
  * Added validation tests to verify URL/path formatting when using path-style addressing with endpoint prefixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/lua-resty-aws-s3/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->